### PR TITLE
refactor: use `lib.generators.toLua`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -21,11 +21,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1674771137,
-        "narHash": "sha256-Zpk1GbEsYrqKmuIZkx+f+8pU0qcCYJoSUwNz1Zk+R00=",
+        "lastModified": 1709336216,
+        "narHash": "sha256-Dt/wOWeW6Sqm11Yh+2+t0dfEWxoMxGBvv3JpIocFl9E=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "7c7a8bce3dffe71203dcd4276504d1cb49dfe05f",
+        "rev": "f7b3c975cf067e56e7cda6cb098ebe3fb4d74ca2",
         "type": "github"
       },
       "original": {
@@ -105,11 +105,11 @@
     "nixpkgs-lib": {
       "locked": {
         "dir": "lib",
-        "lastModified": 1672350804,
-        "narHash": "sha256-jo6zkiCabUBn3ObuKXHGqqORUMH27gYDIFFfLq5P4wg=",
+        "lastModified": 1709237383,
+        "narHash": "sha256-cy6ArO4k5qTx+l5o+0mL9f5fa86tYUX3ozE1S+Txlds=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "677ed08a50931e38382dbef01cba08a8f7eac8f6",
+        "rev": "1536926ef5621b09bba54035ae2bb6d806d72ac8",
         "type": "github"
       },
       "original": {

--- a/modules/lib.nix
+++ b/modules/lib.nix
@@ -1,35 +1,11 @@
 {lib}: let
-  inherit (builtins) isFunction typeOf;
-  inherit (lib) concatStringsSep concatMapStringsSep isDerivation mapAttrsToList mkOption types;
-in rec {
+  inherit (lib) mkOption types;
+in {
   mkLuaOption = type:
     mkOption {
       type = types.nullOr (types.oneOf [type (types.functionTo type)]);
       default = null;
     };
-
-  toLuaHashMap = v: "{ ${concatStringsSep "," (mapAttrsToList (name: value: ''["${name}"] = ${toLua value}'') v)} }";
-
-  toLuaArray = v: "{ ${concatMapStringsSep "," toLua v} }";
-
-  # TODO: Surely there is a better way?
-  toLua = v:
-    if v == null
-    then "nil"
-    else if (typeOf v) == "string"
-    then ''"${v}"''
-    else if (typeOf v) == "bool"
-    then
-      if v
-      then "true"
-      else "false"
-    else if (typeOf v) == "set"
-    then toLuaHashMap v
-    else if (typeOf v) == "list"
-    then toLuaArray v
-    else if isFunction v
-    then v {}
-    else toString v;
 
   # TODO: Maybe?
   # usage: neovim-lib.importPluginFromSpec ./plugins.nix {inherit ...};

--- a/modules/plugins/default.nix
+++ b/modules/plugins/default.nix
@@ -4,7 +4,6 @@
   ...
 }:
 with lib; let
-  inherit (builtins) typeOf;
   inherit (flake-parts-lib) mkPerSystemOption;
   pluginSpec = with types; {
     options = {
@@ -153,10 +152,13 @@ in {
                 in
                   attrValues deps;
               }
-              // optionalAttrs (isDerivation attrs.init || typeOf attrs.init == "path") {
+              // optionalAttrs (isDerivation attrs.init || isPath attrs.init) {
                 init = lib.generators.mkLuaInline ''dofile "${attrs.init}"'';
               }
-              // optionalAttrs (isDerivation attrs.config || typeOf attrs.config == "path") {
+              // optionalAttrs (isBool attrs.config) {
+                inherit (attrs) config;
+              }
+              // optionalAttrs (isDerivation attrs.config || isPath attrs.config) {
                 config = lib.generators.mkLuaInline ''dofile "${attrs.config}"'';
               }
               // optionalAttrs (builtins.isAttrs attrs.config) {


### PR DESCRIPTION
Hi there, thanks for this lovely library, I've been using it for a couple of months for my config 🙂 

I managed to get rid of the custom `toLua` function, and tried it with [my config](https://github.com/nekowinston/neovim.drv), it seems to work fine, but it needs some double-checking.