### PR TITLE
refactor: use `pkgs.writeShellApplication`

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -1,18 +1,14 @@
-name: Build example and run tests
+name: Build and test example flake
 
 on:
   pull_request:
-  push:
-    branches:
-      - main
 
 jobs:
-  tests:
+  check-pr:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: cachix/install-nix-action@v25
         with:
           github_access_token: ${{ secrets.GITHUB_TOKEN }}
-      - run: nix build ./example
-      - run: nix run ./example#test
+      - run: nix run .#check-local

--- a/.github/workflows/update-example.yaml
+++ b/.github/workflows/update-example.yaml
@@ -1,4 +1,4 @@
-name: Update example flake
+name: Update, build and test example flake
 
 on:
   push:
@@ -17,6 +17,7 @@ jobs:
         with:
           github_access_token: ${{ secrets.GITHUB_TOKEN }}
       - run: nix flake lock --update-input neovim-nix ./example
+      - run: nix run .#check
       - run: |
           git config --global user.name 'github-actions[bot]'
           git config --global user.email 'willruggiano@users.noreply.github.com'

--- a/flake.nix
+++ b/flake.nix
@@ -33,6 +33,21 @@
         system,
         ...
       }: {
+        apps = {
+          check.program = pkgs.writeShellApplication {
+            name = "check";
+            text = ''
+              nix run ./example#test
+            '';
+          };
+          check-local.program = pkgs.writeShellApplication {
+            name = "check-local";
+            text = ''
+              nix run --override-input neovim-nix path:./. ./example#test
+            '';
+          };
+        };
+
         devShells.default = pkgs.mkShell {
           name = "neovim.nix";
           shellHook = ''

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -17,11 +17,10 @@
       name = "nvim";
       runtimeInputs = cfg.paths;
       runtimeEnv =
-        {
+        (cfg.env or {})
+        // {
           NVIM_RPLUGIN_MANIFEST = "${config.neovim.build.rplugin}/rplugin.vim";
-        }
-        // (cfg.env or {});
-      meta.mainProgram = "nvim";
+        };
       text = ''
         ${cfg.package}/bin/nvim -u ${cfg.build.initlua} "$@"
       '';


### PR DESCRIPTION
Following #1, I had a look through other todo notes, and this would be my approach.

Tried it on my dots again. ~~Seems that only the formatting changed.~~ (`cfg.env` changed, see my comments)

writeShellApplication already runs shellcheck for us: https://github.com/NixOS/nixpkgs/blob/52544c4a0a84552db4013a8858ade52eaf7ff0ca/pkgs/build-support/trivial-builders/default.nix#L243-L357