### PR TITLE
feat: add python3 options

### DIFF
--- a/modules/default.nix
+++ b/modules/default.nix
@@ -95,7 +95,7 @@ in {
                   default = pkgs.python3;
                   description = "Python interpreter to use for Neovim";
                 };
-                extraPython3Packages = mkOption {
+                extraPackages = mkOption {
                   type = functionTo (listOf package);
                   default = _: [];
                   example =

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -87,6 +87,25 @@ in {
             description = "Additional binaries to bake into the final Neovim derivation's PATH";
           };
 
+          python = mkOption {
+            type = submodule {
+              options = {
+                package = mkOption {
+                  type = package;
+                  default = pkgs.python3;
+                  description = "Python interpreter to use for Neovim";
+                };
+                extraPython3Packages = mkOption {
+                  type = functionTo (listOf package);
+                  default = _: [];
+                  example =
+                    lib.literalExpression "ps: with ps; [requests]";
+                  description = "Python packages to install into the final Neovim derivation";
+                };
+              };
+            };
+          };
+
           final = mkOption {
             type = package;
             description = "The final Neovim derivation, with all user configuration baked in";

--- a/modules/neovim/default.nix
+++ b/modules/neovim/default.nix
@@ -52,7 +52,7 @@ in {
         cfg = config.neovim;
         pythonEnv =
           (cfg.python.package).withPackages
-          (ps: [ps.pynvim] ++ (cfg.python.extraPython3Packages ps));
+          (ps: [ps.pynvim] ++ (cfg.python.extraPackages ps));
         env = pkgs.buildEnv {
           name = "neovim-host-prog";
           paths = [pkgs.nodePackages.neovim pythonEnv];

--- a/modules/neovim/default.nix
+++ b/modules/neovim/default.nix
@@ -49,11 +49,13 @@ in {
       };
 
       config = let
+        cfg = config.neovim;
+        pythonEnv =
+          (cfg.python.package).withPackages
+          (ps: [ps.pynvim] ++ (cfg.python.extraPython3Packages ps));
         env = pkgs.buildEnv {
           name = "neovim-host-prog";
-          paths =
-            [pkgs.nodePackages.neovim]
-            ++ [(pkgs.python3.withPackages (ps: with ps; [pynvim]))];
+          paths = [pkgs.nodePackages.neovim pythonEnv];
         };
       in {
         neovim.build.before = pkgs.writeTextFile {


### PR DESCRIPTION
Mostly lifted from [home-manager](https://github.com/nix-community/home-manager/blob/017b12de5b899ef9b64e2c035ce257bfe95b8ae2/modules/programs/neovim.nix#L152).

Occured to me as a possible improvement since I had to resort to `lib.mkForce` to override `cfg.build.before`, when I tried a python extension [some time ago](https://github.com/nekowinston/neovim.drv/commit/ad875ba1a70fe24e37517f0b2121846f2a06bba8#diff-3cf152b7651b0cd3fe7c49261c2780e9df9d12ef2f6c500f4208de6b0002ae8cR27-R34).