### PR TITLE
feat: allow strings for pluginSpec config via `mkLuaInline`

### DIFF
--- a/modules/plugins/default.nix
+++ b/modules/plugins/default.nix
@@ -5,7 +5,6 @@
 }:
 with lib; let
   inherit (flake-parts-lib) mkPerSystemOption;
-  isLuaInline = e: isAttrs e && matchAttrs {_type = "lua-inline";} e;
   pluginSpec = with types; {
     options = {
       src = mkOption {
@@ -33,7 +32,7 @@ with lib; let
         default = null;
       };
       config = mkOption {
-        type = nullOr (oneOf [attrs bool package path]);
+        type = nullOr (oneOf [attrs bool package path str]);
         default = null;
       };
       opts = mkOption {
@@ -156,13 +155,16 @@ in {
               // optionalAttrs (isDerivation attrs.init || isPath attrs.init) {
                 init = lib.generators.mkLuaInline ''dofile "${attrs.init}"'';
               }
-              // optionalAttrs (isBool attrs.config || isLuaInline attrs.config) {
+              // optionalAttrs (isBool attrs.config) {
                 inherit (attrs) config;
+              }
+              // optionalAttrs (isString attrs.config) {
+                config = lib.generators.mkLuaInline attrs.config;
               }
               // optionalAttrs (isDerivation attrs.config || isPath attrs.config) {
                 config = lib.generators.mkLuaInline ''dofile "${attrs.config}"'';
               }
-              // optionalAttrs (lib.isAttrs attrs.config && !(isLuaInline attrs.config)) {
+              // optionalAttrs (isAttrs attrs.config) {
                 config = true;
                 opts = attrs.config;
               }

--- a/modules/plugins/default.nix
+++ b/modules/plugins/default.nix
@@ -5,6 +5,7 @@
 }:
 with lib; let
   inherit (flake-parts-lib) mkPerSystemOption;
+  isLuaInline = e: isAttrs e && matchAttrs {_type = "lua-inline";} e;
   pluginSpec = with types; {
     options = {
       src = mkOption {
@@ -155,13 +156,13 @@ in {
               // optionalAttrs (isDerivation attrs.init || isPath attrs.init) {
                 init = lib.generators.mkLuaInline ''dofile "${attrs.init}"'';
               }
-              // optionalAttrs (isBool attrs.config) {
+              // optionalAttrs (isBool attrs.config || isLuaInline attrs.config) {
                 inherit (attrs) config;
               }
               // optionalAttrs (isDerivation attrs.config || isPath attrs.config) {
                 config = lib.generators.mkLuaInline ''dofile "${attrs.config}"'';
               }
-              // optionalAttrs (builtins.isAttrs attrs.config) {
+              // optionalAttrs (lib.isAttrs attrs.config && !(isLuaInline attrs.config)) {
                 config = true;
                 opts = attrs.config;
               }


### PR DESCRIPTION
Just occurred to me that `toLua` allows us to use `mkLuaInline` for short `config`s:
```diff
   vim-dadbod-ui = {
     src = srcs.vim-dadbod-ui;
-    # TODO: config file with:
-    # vim.g.db_ui_use_nerd_fonts = true
-    # vim.g.db_ui_win_position = "right"
+    config = lib.generators.mkLuaInline ''
+      function()
+        vim.g.db_ui_use_nerd_fonts = true
+        vim.g.db_ui_win_position = "right"
+      end
+    '';
   };
```

I'm not sure if the current `isLuaInline` is optimal? Sadly, `generators.nix` doesn't export it (and also expects an attrset, so it fails when encountering paths).

---

Alternatively, we could also allow string types and then call mkLuaInline in `{isString attrs.config) {...}`?